### PR TITLE
Use auto-deref other than generics for `Path`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let opt = CLIOpt::from_args();
 
     imx_generator::append_ivt_header(
-        opt.input_path,
-        opt.output_path,
+        &opt.input_path,
+        &opt.output_path,
         opt.entry_point,
         opt.boot_device,
     )?;

--- a/src/program_image.rs
+++ b/src/program_image.rs
@@ -6,9 +6,9 @@ use std::path::Path;
 
 use crate::boot_data::{AsU8Slice, BootData, BootDevice, DCD_DATA, ImageVectorTable};
 
-pub fn append_ivt_header<P: AsRef<Path>>(
-    input_path: P,
-    output_path: P,
+pub fn append_ivt_header(
+    input_path: &Path,
+    output_path: &Path,
     entry_point: u32,
     boot_device: BootDevice,
 ) -> io::Result<()> {


### PR DESCRIPTION
原来的设计里input和output类型必须相同（都是P），现在可以不同